### PR TITLE
Handle invalid messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Supported configuration for endpoints:
 | default    | Use this endpoint as the default in case no match is made |
 | sourceCategory | Default source category | 
 | sourceName | Default source name | 
+| missingSrcCatStrategy | What to do if unable to determine source category or source name based on the configuration. `FallbackToTopic` (default) sets missing metadata to topic name, `Drop` logs the error and ignores the message |
 
 Supported configuration for endpoint jsonOptions:
 
@@ -126,7 +127,7 @@ Supported configuration for endpoint jsonOptions:
 | fieldJsonPaths     | Map of field name to jsonpath for metadata fields |
 | payloadWrapperKey  | Message key which contains the actual message  |
 | payloadJsonPath    | Jsonpath to the log payload  |
-| payloadText        | Sends the payload as raw text. The wrapper key will be ignored with this option. true of false  |
+| payloadText        | Sends the payload as raw text. The wrapper key will be ignored with this option. true or false  |
 
 ## Kubernetes configuration
 Overrides are available in kubernetes using pod annotations. These settings take precedence over default or endpoint settings.

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ lazy val sumologicKafkaPush =
         AkkaHttp,
         Logback,
         Json4sNative,
+        Json4sExt,
         AkkaHttpJson4s,
         AkkaKafka,
         ApacheKafkaClient,

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,8 @@ lazy val sumologicKafkaPush =
         Skuber,
         ScalacacheCore,
         ScalacacheGuava,
-        JsonPath
+        JsonPath,
+        Mockito
       ),
       resolvers ++= Seq(
         Resolver.bintrayRepo("lonelyplanet", "maven")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,6 +28,7 @@ object Dependencies {
   val AkkaHttp = "com.typesafe.akka" %% "akka-http" % Version.AkkaHttp
   val Logback = "ch.qos.logback" % "logback-classic" % Version.Logback
   val Json4sNative = "org.json4s" %% "json4s-native" % Version.Json4s
+  val Json4sExt = "org.json4s" %% "json4s-ext" % Version.Json4s
   val AkkaHttpJson4s = "de.heikoseeberger" %% "akka-http-json4s" % Version.AkkaHttpJson4s
   val AkkaKafka = "com.typesafe.akka" %% "akka-stream-kafka" % Version.AkkaKafka
   val ApacheKafkaClient = "org.apache.kafka" % "kafka-clients" % Version.ApacheKafkaClient

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,8 @@ object Version {
   val Skuber = "2.6.0"
   val Scalacache = "0.28.0"
   val JsonPath = "2.5.0"
+
+  val Mockito = "3.2.9.0"
 }
 
 object Dependencies {
@@ -44,4 +46,5 @@ object Dependencies {
 
   val ScalaTest = "org.scalatest" %% "scalatest" % Version.ScalaTest % Test
   val AkkaTypedTestKit = "com.typesafe.akka" %% "akka-actor-testkit-typed" % Version.Akka % Test
+  val Mockito = "org.scalatestplus" %% "mockito-3-4" % Version.Mockito % Test
 }

--- a/src/main/scala/com/sumologic/sumopush/SumoPushMain.scala
+++ b/src/main/scala/com/sumologic/sumopush/SumoPushMain.scala
@@ -76,18 +76,22 @@ object SumoPushMain {
       .withStopTimeout(Duration.Zero)
   }
 
-  def main(args: Array[String]): Unit = {
-    val log = LoggerFactory.getLogger(getClass)
-    log.info("starting sumo push...")
-
+  def configureJsonPath(): Unit = {
     // jsonpath config
     Configuration.setDefaults(new Configuration.Defaults {
       override def jsonProvider(): JsonProvider = Json4sProvider
 
-      override def options(): util.Set[jsonpath.Option] = Set[jsonpath.Option]().asJava
+      override def options(): util.Set[jsonpath.Option] = Set(jsonpath.Option.SUPPRESS_EXCEPTIONS).asJava
 
       override def mappingProvider(): MappingProvider = new JacksonMappingProvider()
     })
+  }
+
+  def main(args: Array[String]): Unit = {
+    val log = LoggerFactory.getLogger(getClass)
+    log.info("starting sumo push...")
+
+    configureJsonPath()
 
     val confFile = new File("/opt/docker/conf/application.conf")
     val config = if (confFile.exists() && confFile.canRead) {

--- a/src/main/scala/com/sumologic/sumopush/actor/LogProcessor.scala
+++ b/src/main/scala/com/sumologic/sumopush/actor/LogProcessor.scala
@@ -14,7 +14,7 @@ import io.prometheus.client.Counter
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.json4s.JsonAST.{JArray, JObject}
 import org.json4s.native.{JsonMethods, Serialization}
-import org.json4s.{DefaultFormats, Formats, JValue}
+import org.json4s.{DefaultFormats, Formats, JValue, JsonAST}
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.time.Instant
@@ -175,6 +175,7 @@ object LogProcessor extends MessageProcessor {
         case (key, path) =>
           val value = path.read(json).asInstanceOf[Any] match {
             case s: String => s
+            case b: JsonAST.JBool => b.value.toString
             case v: BigInt => v.toString()
             case v: Int => v.toString
             case v: Long => v.toString

--- a/src/main/scala/com/sumologic/sumopush/actor/LogsFlow.scala
+++ b/src/main/scala/com/sumologic/sumopush/actor/LogsFlow.scala
@@ -29,6 +29,7 @@ object LogsFlow {
             ConsumerLogMessage(message.record, message.committableOffset, replyTo)
         })
         .mapConcat {
+          case (Some(requests), offset) if requests.isEmpty => List((None, Some(offset)))
           case (Some(requests), offset) => ((Some(requests.head), Some(offset)) +: requests.drop(1).map(r => (Some(r), None))).toList
           case (None, offset) => List((None, Some(offset)))
         })

--- a/src/main/scala/com/sumologic/sumopush/actor/MetricProcessor.scala
+++ b/src/main/scala/com/sumologic/sumopush/actor/MetricProcessor.scala
@@ -26,7 +26,7 @@ object MetricProcessor extends MessageProcessor {
           (None, Some(offset))
         } else {
           config.getMetricEndpoint(pme) match {
-            case Some(endpoint@SumoEndpoint(Some(name), _, _, _, _, _, _, _, _)) =>
+            case Some(endpoint@SumoEndpoint(Some(name), _, _, _, _, _, _, _, _, _)) =>
               context.log.trace("sumo endpoint name: {}", name)
               messages_processed.labels(if (pme.labels.contains("container")) pme.labels("container") else "", name).inc()
               (Some(createSumoRequestFromLogEvent(config, endpoint, pme)), Some(offset))

--- a/src/main/scala/com/sumologic/sumopush/actor/PushConsumer.scala
+++ b/src/main/scala/com/sumologic/sumopush/actor/PushConsumer.scala
@@ -44,7 +44,7 @@ object PushConsumer {
       .toMat(Committer.sink(committerSettings))(Keep.both)
       .mapMaterializedValue(DrainingControl.apply[Done])
       .withAttributes(ActorAttributes.withSupervisionStrategy(e => {
-        context.log.error("stream error", e)
+        log.error("stream error", e)
         context.self ! ConsumerShutdown
         Supervision.Stop
       }))

--- a/src/main/scala/com/sumologic/sumopush/model/KubernetesLogEvent.scala
+++ b/src/main/scala/com/sumologic/sumopush/model/KubernetesLogEvent.scala
@@ -36,6 +36,7 @@ object KubernetesLogEventSerializer extends CustomSerializer[KubernetesLogEvent]
   case kle: KubernetesLogEvent =>
     implicit val formats: Formats = DefaultFormats + KubernetesSerializer
     ("message" -> kle.message) ~
+      ("stream" -> kle.stream) ~
       ("timestamp" -> kle.timestamp.map(Instant.ofEpochMilli(_).atZone(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))) ~
       ("kubernetes" -> Extraction.decompose(kle.metadata))
 })) {

--- a/src/test/resources/fieldsTypes.json
+++ b/src/test/resources/fieldsTypes.json
@@ -1,0 +1,18 @@
+{
+  "log": {
+    "log": "I0416 19:32:53.813537       1 utils.go:467] Removing unregistered node aws:///us-west-2c/i-testtesttest1test\n"
+  },
+  "category": {
+    "source": "sourceCategory"
+  },
+  "name": {
+    "source": "sourceName"
+  },
+  "additionalFields": {
+    "string": "stringvalue",
+    "bool": true,
+    "int": 100,
+    "bigint": 228930314431312345,
+    "null": null
+  }
+}

--- a/src/test/resources/missingCategory.json
+++ b/src/test/resources/missingCategory.json
@@ -1,0 +1,8 @@
+{
+  "log": {
+    "log": "I0416 19:32:53.813537       1 utils.go:467] Removing unregistered node aws:///us-west-2c/i-testtesttest1test\n"
+  },
+  "name": {
+    "source": "sourceName"
+  }
+}

--- a/src/test/resources/missingField.json
+++ b/src/test/resources/missingField.json
@@ -1,0 +1,14 @@
+{
+  "log": {
+    "log": "I0416 19:32:53.813537       1 utils.go:467] Removing unregistered node aws:///us-west-2c/i-testtesttest1test\n"
+  },
+  "category": {
+    "source": "sourceCategory"
+  },
+  "name": {
+    "source": "sourceName"
+  },
+  "some": {
+    "field": "fieldValue"
+  }
+}

--- a/src/test/resources/missingName.json
+++ b/src/test/resources/missingName.json
@@ -1,0 +1,8 @@
+{
+  "log": {
+    "log": "I0416 19:32:53.813537       1 utils.go:467] Removing unregistered node aws:///us-west-2c/i-testtesttest1test\n"
+  },
+  "category": {
+    "source": "sourceCategory"
+  }
+}

--- a/src/test/resources/missingPayload.json
+++ b/src/test/resources/missingPayload.json
@@ -1,0 +1,8 @@
+{
+  "category": {
+    "source": "sourceCategory"
+  },
+  "name": {
+    "source": "sourceName"
+  }
+}

--- a/src/test/resources/test-fallback.conf
+++ b/src/test/resources/test-fallback.conf
@@ -1,0 +1,21 @@
+include "application"
+
+sumopush.kafka.serdeClass: "com.sumologic.sumopush.serde.JsonLogEventSerde"
+
+endpoints: null
+endpoints: {
+  fallbackTrue: {
+    default: true
+    uri: "http://sumologic.com/ingest/fallbackTrue"
+    jsonOptions: {
+      payloadText: true
+      payloadJsonPath: "$.log.log"
+      sourceCategoryJsonPath: "$.category.source"
+      sourceNameJsonPath: "$.name.source"
+      fieldJsonPaths: {
+        "existingField": "$.some.field"
+        "wrongField": "$.wrong.field",
+      }
+    }
+  }
+}

--- a/src/test/resources/test-field-types.conf
+++ b/src/test/resources/test-field-types.conf
@@ -1,0 +1,24 @@
+include "application"
+
+sumopush.kafka.serdeClass: "com.sumologic.sumopush.serde.JsonLogEventSerde"
+
+endpoints: null
+endpoints: {
+  fallbackTrue: {
+    default: true
+    uri: "http://sumologic.com/ingest/fallbackTrue"
+    jsonOptions: {
+      payloadText: true
+      payloadJsonPath: "$.log.log"
+      sourceCategoryJsonPath: "$.category.source"
+      sourceNameJsonPath: "$.name.source"
+      fieldJsonPaths: {
+        "stringfield": "$.additionalFields.string"
+        "boolfield": "$.additionalFields.bool",
+        "intfield": "$.additionalFields.int",
+        "bigintfield": "$.additionalFields.bigint",
+        "nullField": "$.additionalFields.null",
+      }
+    }
+  }
+}

--- a/src/test/resources/test-nofallback.conf
+++ b/src/test/resources/test-nofallback.conf
@@ -1,0 +1,17 @@
+include "application"
+
+sumopush.kafka.serdeClass: "com.sumologic.sumopush.serde.JsonLogEventSerde"
+
+endpoints: {
+  fallbackFalse: {
+    default: true
+    uri: "http://sumologic.com/ingest/fallbackFalse"
+    missingSrcCatStrategy: "Drop"
+    jsonOptions: {
+      payloadText: true,
+      payloadJsonPath: "$.log.log"
+      sourceCategoryJsonPath: "$.category.source"
+      sourceNameJsonPath: "$.name.source"
+    }
+  }
+}

--- a/src/test/scala/com/sumologic/sumopush/BaseTest.scala
+++ b/src/test/scala/com/sumologic/sumopush/BaseTest.scala
@@ -1,0 +1,12 @@
+package com.sumologic.sumopush
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+trait BaseTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    SumoPushMain.configureJsonPath()
+  }
+}

--- a/src/test/scala/com/sumologic/sumopush/ConfigTest.scala
+++ b/src/test/scala/com/sumologic/sumopush/ConfigTest.scala
@@ -4,11 +4,9 @@ import akka.http.scaladsl.model.{ContentTypes, Uri}
 import com.sumologic.sumopush.actor.LogProcessor
 import com.sumologic.sumopush.model.{KubernetesLogEventSerializer, PromMetricEventSerializer, SumoDataType}
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should._
 
 
-class ConfigTest extends AnyFlatSpec with Matchers {
+class ConfigTest extends BaseTest {
   val cfgEndpoints: Config = ConfigFactory.load().withFallback(ConfigFactory.load("test-endpoints"))
   val cfg: Config = ConfigFactory.load()
   val dataType: SumoDataType.Value = SumoDataType.withName(cfg.getString("sumopush.dataType"))

--- a/src/test/scala/com/sumologic/sumopush/JsonLogTest.scala
+++ b/src/test/scala/com/sumologic/sumopush/JsonLogTest.scala
@@ -1,0 +1,60 @@
+package com.sumologic.sumopush
+
+import com.sumologic.sumopush.actor.LogProcessor
+import com.sumologic.sumopush.model.{LogRequest, SumoDataType}
+import com.typesafe.config.ConfigFactory
+import org.mockito.ArgumentMatchers
+import org.mockito.{Mockito => M}
+import org.scalatestplus.mockito.MockitoSugar
+import org.slf4j.Logger
+import org.slf4j.helpers.NOPLogger
+
+class JsonLogTest extends BaseTest with MockitoSugar {
+  private val withFallback = ConfigFactory.load("test-fallback")
+  private val withoutFallback = ConfigFactory.load("test-nofallback")
+  private val cfgWithFallback = AppConfig(SumoDataType.logs, withFallback)
+  private val cfgWithoutFallback = AppConfig(SumoDataType.logs, withoutFallback)
+
+  private val missingCategoryMsg = Utils.jsonLogEventFromResource("missingCategory.json")
+  private val missingNameMsg = Utils.jsonLogEventFromResource("missingName.json")
+  private val missingPayloadMsg = Utils.jsonLogEventFromResource("missingPayload.json")
+  private val missingFieldMsg = Utils.jsonLogEventFromResource("missingField.json")
+
+  "LogProcessor" should "fallback to topic for missing source category or name" in {
+    val logger = NOPLogger.NOP_LOGGER
+    val categoryFallback = LogProcessor.createSumoRequestsFromLogEvent(cfgWithFallback, "topic", missingCategoryMsg, logger)
+    categoryFallback.size shouldBe 1
+    categoryFallback.head.sourceCategory shouldBe "topic"
+    categoryFallback.head.sourceName shouldBe "sourceName"
+
+    val nameFallback = LogProcessor.createSumoRequestsFromLogEvent(cfgWithFallback, "topic", missingNameMsg, logger)
+    nameFallback.size shouldBe 1
+    nameFallback.head.sourceCategory shouldBe "sourceCategory"
+    nameFallback.head.sourceName shouldBe "topic"
+  }
+
+  "LogProcessor" should "drop and log message with missing source category or name (if configured to do so)" in {
+    val logger = mock[Logger]
+    LogProcessor.createSumoRequestsFromLogEvent(cfgWithoutFallback, "topic", missingCategoryMsg, logger) shouldBe empty
+    LogProcessor.createSumoRequestsFromLogEvent(cfgWithoutFallback, "topic", missingNameMsg, logger) shouldBe empty
+
+    M.verify(logger, M.times(2))
+      .warn(ArgumentMatchers.matches(""".*log.*log.*Removing unregistered node.*source.*source.*""")) //parts of the log message
+  }
+
+  "LogProcessor" should "forward full message if payload field not found" in {
+    val logger = NOPLogger.NOP_LOGGER
+    val logFallback = LogProcessor.createSumoRequestsFromLogEvent(cfgWithFallback, "topic", missingPayloadMsg, logger)
+    logFallback.size shouldBe 1
+    logFallback.head.logs.head should matchPattern {
+      case LogRequest(_, """{"category":{"source":"sourceCategory"},"name":{"source":"sourceName"}}""") =>
+    }
+  }
+
+  "LogProcessor" should "extract fields and not fail for not existing ones" in {
+    val logger = NOPLogger.NOP_LOGGER
+    val logFallback = LogProcessor.createSumoRequestsFromLogEvent(cfgWithFallback, "topic", missingFieldMsg, logger)
+    logFallback.size shouldBe 1
+    logFallback.head.fields shouldBe Seq("existingField=fieldValue")
+  }
+}

--- a/src/test/scala/com/sumologic/sumopush/ProcessorTest.scala
+++ b/src/test/scala/com/sumologic/sumopush/ProcessorTest.scala
@@ -4,12 +4,10 @@ import com.sumologic.sumopush.actor.MessageProcessor
 import com.sumologic.sumopush.actor.MessageProcessor._
 import com.sumologic.sumopush.model.SumoDataType
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should._
 
 class TestProcessor extends MessageProcessor {}
 
-class ProcessorTest extends AnyFlatSpec with Matchers {
+class ProcessorTest extends BaseTest {
   val cfg: Config = ConfigFactory.load()
   val dataType: SumoDataType.Value = SumoDataType.withName(cfg.getString("sumopush.dataType"))
   val appConfig: AppConfig = AppConfig(dataType, cfg)

--- a/src/test/scala/com/sumologic/sumopush/PushTest.scala
+++ b/src/test/scala/com/sumologic/sumopush/PushTest.scala
@@ -2,12 +2,10 @@ package com.sumologic.sumopush
 
 import com.sumologic.sumopush.model._
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should._
 
 import java.time.Instant
 
-class PromMetricModelSpec extends AnyFlatSpec with Matchers {
+class PromMetricModelSpec extends BaseTest {
   val cfg: Config = ConfigFactory.load()
   val dataType: SumoDataType.Value = SumoDataType.withName(cfg.getString("sumopush.dataType"))
   val appConfig: AppConfig = AppConfig(dataType, cfg)

--- a/src/test/scala/com/sumologic/sumopush/Utils.scala
+++ b/src/test/scala/com/sumologic/sumopush/Utils.scala
@@ -1,0 +1,13 @@
+package com.sumologic.sumopush
+
+import com.sumologic.sumopush.model.{JsonLogEvent, JsonLogEventSerializer}
+
+import scala.io.Source
+
+object Utils {
+  def jsonLogEventFromResource(fileName: String): JsonLogEvent = {
+    val source = Source.fromResource(fileName)
+    val content = try source.mkString finally source.close()
+    JsonLogEventSerializer.fromJson(content)
+  }
+}


### PR DESCRIPTION
* fix exceptions thrown when `read`ing non-existent json path
* configurable fallback to topic for source name and category or dropping (logging) invalid messages
* support boolean fields
* minors - fix logging stream error and `KubernetesLogEvent` serialization