### PR TITLE
Add option to embed json fields metadata inside the log payload

### DIFF
--- a/src/main/scala/com/sumologic/sumopush/model/SumoEndpoint.scala
+++ b/src/main/scala/com/sumologic/sumopush/model/SumoEndpoint.scala
@@ -45,7 +45,8 @@ case class JsonOptions(sourceCategoryJsonPath: Option[JsonPath],
                        fieldJsonPaths: Option[Map[String, JsonPath]],
                        payloadWrapperKey: Option[String],
                        payloadJsonPath: Option[JsonPath],
-                       payloadText: Option[Boolean])
+                       payloadText: Option[Boolean],
+                       moveFieldsIntoPayload: Option[Boolean] = None)
 
 object SumoEndpointSerializer extends CustomSerializer[SumoEndpoint](_ => ( {
   case v: JValue =>
@@ -82,7 +83,8 @@ object JsonOptionsSerializer extends CustomSerializer[JsonOptions](_ => ( {
       fieldJsonPaths = (v \ "fieldJsonPaths").extractOpt[Map[String, String]].map { m => m map { case (k, v) => (k, JsonPath.compile(v)) } },
       payloadWrapperKey = (v \ "payloadWrapperKey").extractOpt[String],
       payloadText = (v \ "payloadText").extractOpt[Boolean],
-      payloadJsonPath = (v \ "payloadJsonPath").extractOpt[String].map(JsonPath.compile(_))
+      payloadJsonPath = (v \ "payloadJsonPath").extractOpt[String].map(JsonPath.compile(_)),
+      moveFieldsIntoPayload = (v \ "moveFieldsIntoPayload").extractOpt[Boolean],
     )
 }, {
   case _: JsonOptions =>

--- a/src/test/resources/jsonPayloadWithFields.json
+++ b/src/test/resources/jsonPayloadWithFields.json
@@ -1,0 +1,17 @@
+{
+  "log": {
+    "log": {"timestamp": 1654016401446, "USER": "root", "PID": "3", "CPU": "0.0", "MEM": "0.0"}
+  },
+  "category": {
+    "source": "sourceCategory"
+  },
+  "name": {
+    "source": "sourceName"
+  },
+  "additionalFields": {
+    "string": "stringvalue",
+    "bool": true,
+    "int": 100,
+    "bigint": 228930314431312345
+  }
+}

--- a/src/test/resources/test-fields-in-payload.conf
+++ b/src/test/resources/test-fields-in-payload.conf
@@ -1,0 +1,24 @@
+include "application"
+
+sumopush.kafka.serdeClass: "com.sumologic.sumopush.serde.JsonLogEventSerde"
+
+endpoints: null
+endpoints: {
+  fallbackTrue: {
+    default: true
+    uri: "http://sumologic.com/ingest/fallbackTrue"
+    jsonOptions: {
+      payloadText: true
+      payloadJsonPath: "$.log.log"
+      sourceCategoryJsonPath: "$.category.source"
+      sourceNameJsonPath: "$.name.source"
+      moveFieldsIntoPayload: true
+      fieldJsonPaths: {
+        "stringfield": "$.additionalFields.string"
+        "boolfield": "$.additionalFields.bool",
+        "intfield": "$.additionalFields.int",
+        "bigintfield": "$.additionalFields.bigint",
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adding a boolean option `moveFieldsIntoPayload` to inject specified fields into the log JSON payload to allow for dynamic auto JSON parsing in Sumo. Enabling this option would also prevent fields from being sent in the HTTP request to Sumo.